### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -40,7 +40,7 @@ jobs:
           echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=scottish_mansion_tax_map.html"></head></html>' > _site/index.html
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Create pages directory
         run: |
@@ -44,4 +44,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.